### PR TITLE
Updated docs, and localdb

### DIFF
--- a/doc/splay.org
+++ b/doc/splay.org
@@ -5,9 +5,29 @@
   create a localstore of the IAM data.
 
   #+begin_src bash
-    cd aggie-experts
-
+    cd aggie-test
+    alias experts='node ~/aggie-experts/experts-client/bin/experts.js'
+    experts --iam-auth ${IAM_AUTH} iam getIam
   #+end_src
+
+Now we have a quadstore of iam data.  We can test that works using the localdb
+query.
+
+#+begin_src bash
+    experts localdb --quadstore=iam_quadstore query \
+            --query='prefix : <http://iam.ucdavis.edu/schema#> select ?kerb $filename  where { graph ?g { [] :userID ?kerb. bind(concat("person/",?kerb,".jsonld") as ?filename) } } limit 5'
+#+end_src
+
+Then, we can run the splay command:
+
+#+begin_src bash
+  mkdir person
+  experts splay --quadstore=iam_quadstore \
+          --bind='prefix : <http://iam.ucdavis.edu/schema#> select ?kerb $filename  where { graph ?g { [] :userID ?kerb. bind(concat("person/",?kerb,".jsonld") as ?filename) } } limit 5' \
+          --construct@ ~/aggie-experts/experts-client/queries/iam_person_to_vivo.rq
+#+end_src
+
+
 
 * Grants Example
 

--- a/experts-client/bin/experts-localdb.js
+++ b/experts-client/bin/experts-localdb.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
-import { Command} from 'commander';
+import { Command, Option} from 'commander';
 const program = new Command();
-
 import { localDB } from '../lib/experts-client.js';
 import { Engine } from 'quadstore-comunica';
 
@@ -9,7 +8,7 @@ const db_config = {
   level: process.env.EXPERTS_LEVEL ?? 'ClassicLevel'
 }
 
-program.option('--source <source...>', 'source file(s) to load');
+program.option('--quadstore <quadstore>', 'Specify a local quadstore','./db');
 
 program.command('load <file...>')
   .description('Import jsonld files into the local database')
@@ -24,7 +23,7 @@ program.command('query [file...]')
   .option('-q, --query <query>', 'The query to execute')
   .option('-f, --query@ <rq>', 'File containing the query to execute')
   .description('Preform a query on the local database.  Import any supplied files before querying')
-  .action(async (file,cli) => {
+  .action(async (file,cli,cmd) => {
     console.log('cli:',cli);
     if( ! cli.query ) {
       if(cli['query@']) {
@@ -35,7 +34,7 @@ program.command('query [file...]')
         process.exit(1);
       }
     }
-    const db = await localDB.create(db_config);
+    const db = await localDB.create({...db_config,path:cmd.optsWithGlobals().quadstore});
     await db.load(file);
     const q = new Engine(db.store);
     const bindingsStream = await q.queryBindings(cli.query);


### PR DESCRIPTION
@rakunkel-ucd this branch includes an example of splaying the IAM data, the steps are in doc/splay.org, and the function is still in the experts-splay command.  This should answer you question.  You can see I needed to use a different Engine when using the quadstore, that's what caused the most problems.  If you can't get  the example to work liet me know, otherwise, accept this, and I'll add to dev.

Note, I *did* make one commit to dev kind-of by accident, that included some splay changes.