### PR TITLE
Added Multi-Template, A-Z browse

### DIFF
--- a/services/base-service/models/base/model.js
+++ b/services/base-service/models/base/model.js
@@ -258,6 +258,34 @@ class BaseModel extends FinEsDataModel {
     const res=await this.client.searchTemplate(options);
     return this.compact_search_results(res,params);
   }
+
+  async msearch(opts) {
+
+    opts.index = "expert-read";
+
+    // Fix-up parms
+    for(let i=0;i<opts.search_templates.length;i++) {
+      let template=opts.search_templates[i];
+      if(template?.params) {
+        template.params = this.common_parms(template.params);
+      }
+      if (template?.id) {
+        await this.verify_template(template);
+      }
+    }
+
+    const res=await this.client.msearchTemplate(opts);
+    console.log(res);
+    // Compact each result
+    for(let i=0;i<res.responses.length;i++) {
+      res.responses[i] = this.compact_search_results(
+        res.responses[i],
+        // search_templates are in pairs.  So get second of pair
+        opts.search_templates[2*i+1].params);
+    }
+    return res.responses;
+  }
+
   /** ^^^^TEMPLATE SEARCH^^^^ **/
 
   /**

--- a/services/base-service/models/browse/api.js
+++ b/services/base-service/models/browse/api.js
@@ -36,12 +36,28 @@ router.get('/', async (req, res) => {
     id: "family_prefix",
     params
   };
+  if (params.p) {
   try {
     const template = await experts.search(opts);
     res.send(template);
   } catch (err) {
     console.log('browse/',err);
     res.status(400).send('Invalid request');
+  }
+  } else {
+    try {
+      const search_templates=[];
+      ["A","B","C","D","E","F","G","H","I","J","K","L","M","N","O",
+       "P","Q","R","S","T","U","V","W","X","Y","Z"].forEach((letter) => {
+         search_templates.push({});
+         search_templates.push({id:"family_prefix",params:{p:letter,size:0}});
+        });
+      const templates = await experts.msearch({search_templates});
+      res.send(templates);
+    } catch (err) {
+      console.log('browse/',err);
+      res.status(400).send('Invalid request');
+    }
   }
 });
 


### PR DESCRIPTION
This adds an additional feature to the `api/browse` endpoint.  If you do *not* supply the endpoint with a prefix `p`, then the API will respond with a result count of all the letters.  The result looks like this:

```json
[
{
"params": {
"size": 0,
"from": 0,
"p": "A"
},
"total": 7,
"hits": []
},
{
"params": {
"size": 0,
"from": 0,
"p": "B"
},
"total": 9,
"hits": []
},
...
```

This may look a little strange at first, but this the equivalent to the idea that the client made a set of template queries like 
`/browse/?p=A&size=0` and then combined them together into an array.  This will be consistent if we need to do other multi-template searches.

