### PR TITLE
Qh try catch

### DIFF
--- a/harvest/Dockerfile
+++ b/harvest/Dockerfile
@@ -99,7 +99,7 @@ RUN cd ${AE_API} && npm link
 ARG AE_CLIENT=/usr/local/lib/experts-client
 COPY experts-client ${AE_CLIENT}
 WORKDIR ${AE_CLIENT}
-RUN npm link @ucd-lib/experts-api && npm install && npm install -g
+RUN rm -f package-lock.json && npm link @ucd-lib/experts-api && npm install -g
 
 # Setup a place to hold the Makefile data
 RUN mkdir /usr/local/lib/harvest

--- a/harvest/experts-client/bin/experts-cdl.js
+++ b/harvest/experts-client/bin/experts-cdl.js
@@ -185,17 +185,24 @@ async function main(opt) {
       const bindings = BF.fromRecord(
         { EXPERTS_SERVICE__: DF.namedNode(opt.expertsService) }
       );
-      const iam = ql.getQuery('insert_iam', 'InsertQuery');
-
-      await ec.insert({ ...iam, bindings, db });
-
+      try {
+        const iam = ql.getQuery('insert_iam', 'InsertQuery');
+        await ec.insert({ ...iam, bindings, db });
+      } catch (e) {
+        console.error(`insert_iam error ${e}, during insert user ${user}`);
+      }
       for (const n of ['expert', 'authorship', 'grant_role']) {
-        await (async (n) => {
-          const splay = ql.getSplay(n);
-          // While we test, remove frame
-          delete splay['frame'];
-          return await ec.splay({ ...splay,bindings, db });
-        })(n);
+        try {
+          await (async (n) => {
+            const splay = ql.getSplay(n);
+            // While we test, remove frame
+            delete splay['frame'];
+            return await ec.splay({ ...splay,output:opt.output,bindings, db });
+          })(n);
+        } catch (e) {
+          console.error(`splay error ${e}, during ${n} user ${user}`);
+        }
+
       };
     }
     // Any other value don't delete

--- a/harvest/experts-client/lib/readablePromiseQueue.js
+++ b/harvest/experts-client/lib/readablePromiseQueue.js
@@ -29,7 +29,7 @@ export class readablePromiseQueue {
 
     await new Promise((resolve, reject) => {
       this.readable.on('end', () => {
-        Promise.all(this.queue)
+        Promise.allSettled(this.queue)
           .then( results => {
             console.log(`${this.name} promises finished`);
             resolve(results); })

--- a/services/base-service/Dockerfile
+++ b/services/base-service/Dockerfile
@@ -28,13 +28,13 @@ RUN npm ci && \
 # COPY over experts-api source code
 ARG AE_API=/usr/local/lib/aggie-experts/experts-api
 COPY --from=api ${AE_API} ${AE_API}
-RUN (cd ${AE_API} && npm link)
+RUN cd ${AE_API} && npm link
 
 # Models
 WORKDIR ${FIN_SERVICE_ROOT}
 COPY models models
 WORKDIR ${FIN_SERVICE_ROOT}/models
-RUN mv package-lock.json package-lock.json- && npm link @ucd-lib/experts-api && npm install
+RUN rm -f package-lock.json && npm link @ucd-lib/experts-api && npm install
 
 WORKDIR ${FIN_SERVICE_ROOT}
 


### PR DESCRIPTION
experts-cdl needs to be updated so that fetch failures do not stop the entire process, but instead continue on with processing.

This wraps the splay comands in try-catch loops, and also update the promiseQueue