### PR TITLE
Updated harvester for aggie-experts project

### DIFF
--- a/bin/aggie-experts
+++ b/bin/aggie-experts
@@ -45,6 +45,16 @@ The test and prod environments are for the production code.  They require
 specific tags, and deploy only from images pushed to the aggie-experts
 repository.
 
+=item B<--template=I<template>>
+
+Set the template to use for the environment.  The default template brings up the
+entire system.  You can also specify C<--template=fuseki> to bring up only the
+fuseki server.
+
+=item B<--no-fuseki>
+
+When using the default template, do not bring up the fuseki server.
+
 =item B<--mount=I<spa,models,init>>
 
 In the dev environment, you can specify which bind mounts you want to use.  This
@@ -102,11 +112,16 @@ declare -g -A G=(
   [shell_getopt]=${FLAGS_GETOPT_CMD:-getopt}
   [git]="git -C $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
   [dry-run]=
+  [include_fuseki]=1
+  [template]=default
   [cloudsdk_active_config_name]='aggie-experts'
 );
 
 function G() {
-  expand < ${G[config]} | jq "${G[jq]}" | jq -r "$*"
+  if [[ -z ${G[expanded]} ]] ; then
+    G[expanded]=$(expand < ${G[config]} | jq ${G[jq]})
+  fi
+  jq -r "$*" <<<"${G[expanded]}"
 }
 
 : <<'=cut'
@@ -503,28 +518,7 @@ function setup() {
     local tag="$(G .tag // .envs.${G[env]}.tag)"
     local gcs="$(G .gcs // .envs.${G[env]}.gcs)"
 
-    local deploy
-    case ${G[env]} in
-      dev | clean )
-        deploy=dev
-        ;;
-      sandbox )
-        deploy=sandbox
-        ;;
-      test)
-        deploy=test
-        ;;
-      prod )
-        deploy=prod
-        ;;
-      *)
-        >&2 echo "ERR: Unknown environment: ${G[env]}"
-        exit 1
-        ;;
-    esac
-
-
-    local secret=$(basename $(gcloud --format=json secrets list --filter="labels.type:env AND labels.env:$deploy" | jq -r '.[0].name'))
+    local secret=$(basename $(gcloud --format=json secrets list --filter="labels.type:env AND labels.env:${G[env]}" | jq -r '.[0].name'))
 
     gcloud secrets versions access latest --secret="$secret"
 
@@ -544,7 +538,7 @@ function setup() {
   function compose() {
     local env=$(G .env)
     local keycloak=$(G .keycloak)
-    local tmpl=$(G .template)
+    local tmpl=$(G .template.${G[template]})
 
     local org=$(G .org // .envs.${G[env]}.org)
     local tag=$(G .tag // .envs.${G[env]}.tag)
@@ -554,6 +548,11 @@ function setup() {
 
     if [[ "$env" = "dev" ]]; then
       cat $tmpl |
+        if [[ -z ${G[include_fuseki]} ]]; then
+          yq 'del(.services.fuseki)'
+        else
+          cat
+        fi |
         if [[ "$keycloak" != "local" ]]; then
           yq 'del(.services.keycloak)'
         else
@@ -654,7 +653,7 @@ function setup() {
 function main.cmd() {
   local opts;
 
-  if ! opts=$(${G[shell_getopt]} -o nv:d:lh --long gcs:,env:,jq:,list-mounts,mount:,unstaged-ok,no-env,no-compose,no-service-account,cloudsdk-active-config-name:,dry-run,help -n "aggie-experts" -- "$@"); then
+  if ! opts=$(${G[shell_getopt]} -o nv:d:lh --long gcs:,env:,jq:,list-mounts,mount:,unstaged-ok,no-env,no-compose,no-service-account,cloudsdk-active-config-name:,template:,no-fuseki,dry-run,help -n "aggie-experts" -- "$@"); then
     echo "Bad Command Options." >&2 ; exit 1 ; fi
 
     eval set -- "$opts"
@@ -673,6 +672,8 @@ function main.cmd() {
         --gcs) CMD[gcs]=$2; shift 2;;
         --no-env) CMD[setup_env]=; shift;;
         --no-compose) CMD[setup_compose]=; shift;;
+        --no-fuseki) CMD[include_fuseki]=; shift;;
+        --template) CMD[template]=$2; shift 2;;
         --no-service-account) CMD[setup_service_account]=; shift;;
         -l | --list-mounts) CMD[list-mounts]=1; shift;;
         -n | --dry-run) CMD[dry-run]="echo"; shift;;
@@ -689,7 +690,7 @@ function main.cmd() {
 
     # command line over global
     for i in "${!CMD[@]}"; do
-      [[ -n ${CMD[$i]} ]] && G[$i]=${CMD[$i]};
+      G[$i]=${CMD[$i]};
     done
 
     # set the google cloud sdk config

--- a/bin/aggie-experts
+++ b/bin/aggie-experts
@@ -69,9 +69,12 @@ the bounded mounts.
 Show what you would do do not really do it. Because some commands require
 multiple access to the server, this command does not always work properly.
 
-=item B<gcs=I<bucket>>
+=item B<--gcs=I<bucket>>
 
-=item B<unstaged-ok>
+Specify the Google Cloud Storage bucket to use for initialization.  This sets
+the C<GCS_BUCKET> parameter in the environment.
+
+=item B<--unstaged-ok>
 
 Will build a C<clean>) environment even if there are unstaged changes in the
 repository.  This usually means files that are not tracked by git.
@@ -81,13 +84,12 @@ repository.  This usually means files that are not tracked by git.
 List the bind mounts that are used in the dev environment.  Used with the
 C<setup> command.
 
-
 =item B<--no-env> B<--no-service-account> B<--no-compose>
 
 When running C<setup> do not create the environment, service account, or
 docker-compose.yml file, dpepending on the flag.
 
-=item B<-cloudsdk-active-config-name=I<name>>
+=item B<--cloudsdk-active-config-name=I<name>>
 
 Specify the name of the gcloud configuration to use.  This is used to set the
 configuration for the duration of the command. Set to the empty string to use
@@ -136,14 +138,14 @@ pull requests.  The C<sandbox> environment can deploy any commit in a space for
 multiple reviewers.  Once the code is ready for production, it is built in the
 C<build> environment, and then deployed to the C<test> and C<prod> environments.
 
-C<aggie-experts [--env=<dev|clean|sandbox|build>] build> Builds the docker
+C<aggie-experts [--env=dev|clean|sandbox|build] build> Builds the docker
 images.  Builds to C<org=localhost> images in dev,clean, and sandbox
 environments.  C<org=gcr.io./aggie-experts> images in the build environment.
 
-C<aggie-experts [--env=<dev|clean|sandbox|test|prod>] setup> Sets up the C<.env>
+C<aggie-experts [--env=dev|clean|sandbox|test|prod] setup> Sets up the C<.env>
 and C<docker-compose.yaml> files for the specified environment.
 
-C<aggie-experts [--list-mounts] [--mount=<mnt,mnt,..>] [--env=dev] setup> When
+C<aggie-experts [--list-mounts] [--mount=mnt,mnt,..] [--env=dev] setup> When
 in the C<dev> environment, you have the option of setting up bind mounts for the
 C<spa>, C<models>, and C<init> directories.  This allows you to work on the code
 without having to rebuild the docker images.
@@ -153,17 +155,17 @@ The --list-mounts option will list the available bind mounts.
 There are some commands that are used to manage the environment, and are not
 used in the main workflow.
 
-C<aggie-experts [--env=<any>] test-env> Lets the developer test their
+C<aggie-experts [--env=any] test-env> Lets the developer test their
 environment, primarily with respect to the git branch and status.
 
-C<aggie-experts [--env=<any>] guess-env> Shows what environments are available
-in the current host and git configuation.  If multiple environments are available, the developer must explicitly specify the environment C<--env=<env>>.
+C<aggie-experts [--env=any] guess-env> Shows what environments are available
+in the current host and git configuation.  If multiple environments are available, the developer must explicitly specify the environment C<--env=I<env>>.
 
-C<aggie-experts [--env=<any>] prune> Prunes aggie-experts images from the local
+C<aggie-experts [--env=any] prune> Prunes aggie-experts images from the local
 docker setup, based on the environment, and the git repository status.  This can
 be used to clean up the local docker environment.
 
-=head1 COMMANDS
+=head1 ADDITIONAL COMMANDS
 
 =cut
 
@@ -341,6 +343,8 @@ function test_env() {
 =head2 expand
 
 Use shell expansion to expand the config.json file into the current actual variables.
+
+C<aggie-experts expand>
 
 =cut
 #https://stackoverflow.com/questions/415677/how-to-replace-placeholders-in-a-text-file
@@ -765,3 +769,26 @@ function main.cmd() {
 }
 main.cmd "$@"
 exit $?
+
+: <<=cut
+=pod
+
+=head1  EXAMPLES
+
+=head2 SETUP
+
+To setup just fuseki:
+
+C<aggie-expert --env=dev --template=fuseki setup>
+
+To setup the full stack:
+
+C<aggie-expert --env=dev setup>
+
+To skip fuseki:
+
+C<aggie-expert --env=dev --no-fuseki setup>
+
+=head1 AUTHOR
+
+qjhart@ucdavis.edu

--- a/config.json
+++ b/config.json
@@ -44,7 +44,10 @@
       "gcs":"fcrepo-prod"
     }
   },
-  "template":"${G[base]}/docker-template.yaml",
+  "template": {
+    "default":"${G[base]}/docker-template.yaml",
+    "fuseki":"${G[base]}/docker-template-fuseki.yaml"
+  },
   "fin":{
     "org":"gcr.io/ucdlib-pubreg",
     "tag":"2.3.1"

--- a/docker-template-fuseki.yaml
+++ b/docker-template-fuseki.yaml
@@ -1,0 +1,25 @@
+version: '3'
+
+services:
+  # Fuseki is used to harvest data, and as a check on data as well
+  fuseki:
+    image: &IMG ${ORG}/harvest:${TAG}
+    volumes:
+      - fuseki-data:/home/ucd.process
+    ports:
+      - ${DB_PORT:-3030}:3030
+    environment:
+      - JVM_ARGS=${JVM_ARGS:- -Xmx16g}
+    restart: unless-stopped
+    command:
+      HDT=import server
+    # command: bash -c 'tail -f /dev/null'
+    volumes:
+      - &SERVICE_ACCOUNT ${GCLOUD_SERVICE_ACCOUNT_MOUNT:-./service-account.json}:/etc/fin/service-account.json
+
+###
+# Docker data volumes
+###
+volumes:
+  fuseki-data:
+    driver: local

--- a/docker-template.yaml
+++ b/docker-template.yaml
@@ -16,6 +16,24 @@ services:
     command: npm run gateway
     # command: bash -c 'tail -f /dev/null'
 
+  # Fuseki is used to harvest data, and as a check on data as well
+  fuseki:
+    image: &IMG ${ORG}/harvest:${TAG}
+    volumes:
+      - fuseki-data:/home/ucd.process
+    ports:
+      - ${DB_PORT:-3030}:3030
+    environment:
+      - JVM_ARGS=${JVM_ARGS:- -Xmx16g}
+      - GOOGLE_APPLICATION_CREDENTIALS_JSON=${GOOGLE_APPLICATION_CREDENTIALS_JSON}
+    restart: unless-stopped
+    volumes:
+      - *SERVICE_ACCOUNT
+    command:
+      HDT=import server
+    # command: bash -c 'tail -f /dev/null'
+
+
   ###
   # Fedora Repository
   ###
@@ -223,6 +241,8 @@ services:
 # Docker data volumes
 ###
 volumes:
+  fuseki-data:
+    driver: local
   fedora-data:
     driver: local
   pg-data:

--- a/harvest/harvest-entrypoint.sh
+++ b/harvest/harvest-entrypoint.sh
@@ -11,10 +11,12 @@ function init_local_user() {
 }
 
 function gcloud_auth() {
-  if [[ -n ${GOOGLE_APPLICATION_CREDENTIALS_JSON} ]]; then
+  if [[ -f /etc/fin/service-account.json ]]; then
+    gcloud auth activate-service-account --key-file /etc/fin/service-account.json
+  elif [[ -n ${GOOGLE_APPLICATION_CREDENTIALS_JSON} ]]; then
     gcloud auth activate-service-account --key-file=- <<< "${GOOGLE_APPLICATION_CREDENTIALS_JSON}"
   else
-    echo "GOOGLE_APPLICATION_CREDENTIALS_JSON is not set"
+    echo "no /etc/fin/service-account.json and GOOGLE_APPLICATION_CREDENTIALS_JSON is not set"
   fi
 }
 
@@ -23,7 +25,15 @@ init_local_user
 uid=$(id -u)
 if [[ ${uid} = 0 ]]; then
   # Don't cd, because users may want to set their own workdir
-  setpriv --reuid=ucd.process --init-groups -- bash -c 'if [[ -n ${GOOGLE_APPLICATION_CREDENTIALS_JSON} ]]; then gcloud auth activate-service-account --project=digital-ucdavis-edu --key-file=- <<< "${GOOGLE_APPLICATION_CREDENTIALS_JSON}"; echo ${GOOGLE_APPLICATION_CREDENTIALS_JSON} > /home/ucd.process/.config/gcloud/application_default_credentials.json; fi;'
+  setpriv --reuid=ucd.process --init-groups -- bash -c '
+  if [[ -f /etc/fin/service-account.json ]]; then
+    gcloud auth activate-service-account --key-file /etc/fin/service-account.json
+  elif [[ -n ${GOOGLE_APPLICATION_CREDENTIALS_JSON} ]]; then
+    gcloud auth activate-service-account --key-file=- <<< "${GOOGLE_APPLICATION_CREDENTIALS_JSON}"
+  else
+    echo "no /etc/fin/service-account.json and GOOGLE_APPLICATION_CREDENTIALS_JSON is not set"
+  fi
+'
   exec setpriv --reuid=ucd.process --init-groups make --file=/usr/local/lib/harvest/Makefile "$@"
 else
   exec make --file=/usr/local/lib/harvest/Makefile "$@"

--- a/harvest/harvest/Makefile
+++ b/harvest/harvest/Makefile
@@ -43,7 +43,7 @@ server_bg: server_startup
 # gcloud import/export
 #
 # USES GCS_GRAPH_STORAGE if set as env variable
-GCS_GRAPH_STORAGE ?= gs://aggie-experts-sandbox/databases
+GCS_GRAPH_STORAGE ?= gs://fuseki-db
 
 hdt-bucket:=${GCS_GRAPH_STORAGE}
 


### PR DESCRIPTION
The default template for aggie-experts server now includes a fuseki instance by default.  On initialization, it will download the latest versions of the grants and IAM data. 


UI developers may not want to include that step, in which case you can setup Aggie Experts without fuseki with the `-no-fuseki`  option (in development) 

```bash
bin/aggie-experts --env=dev --no-fuseki setup
```

You can also run **only** fuseki, by specifying the `fuseki` docker template.

```bash
bin/aggie-experts --env=dev --template=fuseki setup
```

You can continue to run fuseki by itself in the old manner as well, with the updated application credential. 

```bash
docker run --name iam -p 3030:3030 --env GOOGLE_APPLICATION_CREDENTIALS_JSON="$(gcloud secrets versions access latest --secret='content-reader' | jq -c .)" --interactive --tty --rm  localhost/aggie-experts/harvest:dirty HDT=import server
```

