### PR TITLE
Fixed citation ark: urls. Fixes #326

### DIFF
--- a/bin/aggie-experts
+++ b/bin/aggie-experts
@@ -519,8 +519,8 @@ function setup() {
   read env root <<<$(G "[.env,.git.root] | @tsv" )
 
   function env_file() {
-    local env org tag fin_org fin_tag host port auth client_id sa gcs
-    read  env org tag fin_org fin_tag host port auth client_id sa gcs \
+    local env org tag fin_org fin_tag host port auth client_id sa gcs propagate
+    read  env org tag fin_org fin_tag host port auth client_id sa gcs propagate\
           <<<$(G "[.env,
                    .org // .envs.${G[env]}.org,
                    .tag // .envs.${G[env]}.tag,
@@ -531,7 +531,8 @@ function setup() {
                    .envs.${G[env]}.auth.server,
                    .envs.${G[env]}.auth.client_id,
                    .envs.${G[env]}.auth.service_account,
-                   .gcs // .envs.${G[env]}.gcs]|@tsv")
+                   .gcs // .envs.${G[env]}.gcs,
+                   .envs.${G[env]}.cdl.propagate_changes // .envs.default.cdl.propagate_changes]|@tsv")
 
     [[ "$env" == "clean" ]] && env='dev'
 
@@ -548,6 +549,7 @@ function setup() {
     echo "$oidc_env"
     echo -e "FIN_ORG=$fin_org\nFIN_TAG=$fin_tag\nORG=$org\nTAG=$tag"
     echo -e "GCS=$gcs"
+    echo -e "CDL_PROPAGATE_CHANGES=$propagate"
   }
 
   function service_account() {

--- a/config.json
+++ b/config.json
@@ -2,6 +2,11 @@
   "project":"${G[project]}",
   "env":"${G[env]}",
   "envs": {
+    "default":{
+      "cdl":{
+        "propagate_changes":"false"
+      }
+    },
     "dev":{
       "mount":"spa",
       "auth": {
@@ -103,7 +108,10 @@
       },
       "gcs":"fcrepo-prod",
       "host":"https://experts.ucdavis.edu",
-      "branch":"main"
+      "branch":"main",
+      "cdl":{
+        "propagate_changes":"true"
+      }
     }
   },
   "template": {

--- a/harvest/experts-client/lib/query/authorship/construct.rq
+++ b/harvest/experts-client/lib/query/authorship/construct.rq
@@ -67,7 +67,7 @@ WHERE {
             {
                 select (?RELATIONSHIP__ as ?relationship) ?pub ?record ?source ?score
               WHERE {
-                
+
                 graph cdl: {
                       VALUES (?source ?order) {
                        ("verified-manual" 1)("repec" 2)("dimensions" 3)("pubmed" 4)
@@ -75,16 +75,16 @@ WHERE {
                         ("arxiv" 10)("orcid" 11)("dblp" 12)
                         ("cinqii-english" 13)("figshare" 14)
                         ("cinii-japanese" 15)("manual" 16)("dspace" 17) }
-              
+
                   ?RELATIONSHIP__ :type "publication-user-authorship";
                                   :related ?pub;
                                   .
-              
+
                   # This needs to include grants later
                   ?pub :category "publication";
                                :records/:record ?record.
                       ?record :source-name ?source.
-              
+
                   OPTIONAL {
                     ?record :native/:field/:name "doi".
                     bind(-10 as ?boost)
@@ -138,7 +138,7 @@ WHERE {
     {
         select (?RELATIONSHIP__ as ?relationship) ?pub ?record ?source ?score
       WHERE {
-        
+
         graph cdl: {
               VALUES (?source ?order) {
                ("verified-manual" 1)("repec" 2)("dimensions" 3)("pubmed" 4)
@@ -146,16 +146,16 @@ WHERE {
                 ("arxiv" 10)("orcid" 11)("dblp" 12)
                 ("cinqii-english" 13)("figshare" 14)
                 ("cinii-japanese" 15)("manual" 16)("dspace" 17) }
-      
+
           ?RELATIONSHIP__ :type "publication-user-authorship";
                           :related ?pub;
                           .
-      
+
           # This needs to include grants later
           ?pub :category "publication";
                        :records/:record ?record.
               ?record :source-name ?source.
-      
+
           OPTIONAL {
             ?record :native/:field/:name "doi".
             bind(-10 as ?boost)
@@ -234,7 +234,7 @@ WHERE {
       {
           select (?RELATIONSHIP__ as ?relationship) ?pub ?record ?source ?score
         WHERE {
-          
+
           graph cdl: {
                 VALUES (?source ?order) {
                  ("verified-manual" 1)("repec" 2)("dimensions" 3)("pubmed" 4)
@@ -242,16 +242,16 @@ WHERE {
                   ("arxiv" 10)("orcid" 11)("dblp" 12)
                   ("cinqii-english" 13)("figshare" 14)
                   ("cinii-japanese" 15)("manual" 16)("dspace" 17) }
-        
+
             ?RELATIONSHIP__ :type "publication-user-authorship";
                             :related ?pub;
                             .
-        
+
             # This needs to include grants later
             ?pub :category "publication";
                          :records/:record ?record.
                 ?record :source-name ?source.
-        
+
             OPTIONAL {
               ?record :native/:field/:name "doi".
               bind(-10 as ?boost)
@@ -265,12 +265,12 @@ WHERE {
         ?user :category "user";
               :username ?username;
               .
-    
+
         ?record :native/:field ?field.
         ?field :name "authors";
                :people/:person [ list:index(?pos ?elem) ] .
         ?elem :links/:link ?user.   # This is the link to the relationship user
-    
+
       }
     } limit 1
   }
@@ -318,8 +318,8 @@ WHERE {
   # EXPERTS ids
   BIND(xsd:dateTime(?lastModifiedWhen) AS ?lastModifiedDateTime)
   BIND(concat(?begin,coalesce(concat('-',?end),'')) AS ?page)
-  bind(uri(replace(str(?relationship),str(cdl:),concat(str(experts:),"ark:/87287/d7mh2m/relationship/"))) as ?authorship)
-  bind(uri(replace(str(?pub),str(cdl:),concat(str(experts:),"ark:/87287/d7mh2m/publication/"))) as ?work)
+  bind(uri(replace(str(?relationship),str(cdl:),"ark:/87287/d7mh2m/relationship/")) as ?authorship)
+  bind(uri(replace(str(?pub),str(cdl:),"ark:/87287/d7mh2m/publication/")) as ?work)
   bind(uri(concat(str(expert:),md5(?username))) as ?expert)
   # pub date
   BIND(concat("-",IF(xsd:integer(?pub_m_raw) < 10, CONCAT("0", ?pub_m_raw), ?pub_m_raw)) AS ?pub_month)
@@ -333,7 +333,7 @@ WHERE {
   # journal
   BIND(uri(concat(str(venue:),"urn:issn:",?issn)) as ?journalURI)
   # authors
-  BIND(uri(concat(str(?pub),"#",str(?pos+1))) as ?author)
+  bind(uri(concat(replace(str(?pub),str(cdl:),"ark:/87287/d7mh2m/publication/"),"#",str(?pos+1))) as ?author)
   BIND(?pos+1 as ?rank)
 
 }

--- a/services/base-service/models/authorship/model.js
+++ b/services/base-service/models/authorship/model.js
@@ -100,21 +100,20 @@ class AuthorshipModel extends BaseModel {
     await expertModel.update_graph_node(expertId,node);
 
     // Update FCREPO
-    let bad_id = `<http://experts.ucdavis.edu/${id}>`
     let options = {
       path: expertId + '/' + id,
       content: `
         PREFIX ucdlib: <http://schema.library.ucdavis.edu/schema#>
         DELETE {
-          ${patch.visible != null ? `${bad_id} ucdlib:is-visible ?v .`:''}
-          ${patch.favourite !=null ?`${bad_id} ucdlib:is-favourite ?f .`:''}
+          ${patch.visible != null ? `${id} ucdlib:is-visible ?v .`:''}
+          ${patch.favourite !=null ?`${id} ucdlib:is-favourite ?f .`:''}
         }
         INSERT {
-          ${patch.visible != null ?`${bad_id} ucdlib:is-visible ${patch.visible} .`:''}
-          ${patch.favourite != null ?`${bad_id} ucdlib:is-favourite ${patch.favourite} .`:''}
+          ${patch.visible != null ?`${id} ucdlib:is-visible ${patch.visible} .`:''}
+          ${patch.favourite != null ?`${id} ucdlib:is-favourite ${patch.favourite} .`:''}
         } WHERE {
-          ${bad_id} ucdlib:is-visible ?v .
-          OPTIONAL { ${bad_id} ucdlib:is-favourite ?fav } .
+          ${id} ucdlib:is-visible ?v .
+          OPTIONAL { ${id} ucdlib:is-favourite ?fav } .
         }
       `
     };


### PR DESCRIPTION
This patch makes the `arks:` in citations first class URLs.  This matches grant_roles.