### PR TITLE
web_label/web_type optional

### DIFF
--- a/harvest/experts-client/lib/query/expert/construct.rq
+++ b/harvest/experts-client/lib/query/expert/construct.rq
@@ -140,14 +140,18 @@ WHERE {
                             :web-addresses/:web-address [ list:index(?pos ?elem) ]
                           ].
 
-        ?elem :label ?web_label;
+        ?elem :url ?web_url;
               :privacy "public";
-              :type ?web_type_text;
-              :url ?web_url;
               .
+        OPTIONAL {
+          ?elem :label ?web_label.
+          }
 
+        OPTIONAL {
+          ?elem :type ?web_type_text.
+          bind(uri(concat(str(ucdlib:),"URL_",?web_type_text)) as ?web_type)
+        }
         bind(?pos as ?web_rank)
-        bind(uri(concat(str(ucdlib:),"URL_",?web_type_text)) as ?web_type)
       }
       values (?field_name ?field_predicate ) {
         ("overview" vivo:overview)


### PR DESCRIPTION
CDL elements allows users to add simply a URL to their Elements profile.   The current conversion only added webslite links if the entry also had a label and type.  

This change makes the label and type optional.  For example using these websites as examples:
![image](https://github.com/ucd-library/aggie-experts/assets/344953/6e4b5ad5-3f3e-4a9b-a600-c35a8c95391c)

This change catches them all: 
```json
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1",
"@type": "vcard:Individual",
"isPreferred": false,
"name": "Hart, Quinn § APPLICATIONS PRG SUPV 2, UCDLIBRARY",
"rank": 20,
"hasEmail": "mailto:qjhart@ucdavis.edu",
"hasName": {
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-name",
"@type": "Name",
"family": "Hart",
"given": "Quinn"
},
"hasURL": [
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-web-4",
"@type": [
"URL",
"ucdlib:URL_department"
],
"rank": 4,
"url": "https://library.ucdavis.edu/"
},
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-web-0",
"@type": "URL",
"rank": 0,
"name": "Evaporation (Meteorology)",
"url": "http://id.worldcat.org/fast/917080"
},
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-web-5",
"@type": [
"URL",
"ucdlib:URL_company"
],
"rank": 5,
"url": "https://ucdavis.edu/"
},
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-web-1",
"@type": [
"URL",
"ucdlib:URL_department"
],
"rank": 1,
"name": "Library Bio",
"url": "https://library.ucdavis.edu/person/quinn-hart/"
},
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-web-2",
"@type": "URL",
"rank": 2,
"url": "https://library.ucdavis.edu/online-strategies"
},
{
"@id": "expert/66356b7eec24c51f01e757af2b27ebb8#vcard-oap-1-web-3",
"@type": [
"URL",
"ucdlib:URL_googlescholar"
],
"rank": 3,
"url": "https://scholar.google.com/citations?user=Od5weOkAAAAJ&hl=en&inst=9081605168663377197"
}
]
}
```