### PR TITLE
FCREPO configuration updates

### DIFF
--- a/docker-template.yaml
+++ b/docker-template.yaml
@@ -50,7 +50,10 @@ services:
     # Example for change logging.  Note, don't forget to still include the fcrepo.properties file location!
     # See: https://wiki.lyrasis.org/display/FEDORA6x/Logging
     # environment:
-    #  - CATALINA_OPTS=-Dfcrepo.log.auth=DEBUG -Dfcrepo.config.file=/etc/fin/fcrepo.properties
+    #  - CATALINA_OPTS=-Dfcrepo.log.auth=DEBUG
+    #  -Dfcrepo.config.file=/etc/fin/fcrepo.properties
+    environment:
+      - CATALINA_OPTS=-Dfcrepo.config.file=/etc/fin/fcrepo.properties -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Xms2G -Xmx6G -XX:+UseG1GC -XX:+DisableExplicitGC
     volumes:
       - fedora-data:/usr/local/tomcat/fcrepo-home/data
       - activemq-data:/usr/local/tomcat/ActiveMQ


### PR DESCRIPTION
Justin pointed out to me a number of suggested [JVM configurations for FCREPO](https://wiki.lyrasis.org/display/FEDORA6x/JVM) He plans to incorporate these in to the standard FIN fcrepo, but it's not there yet.  This updates our docker-compose files, with this fix.

It's been tested, but I'm keen to get it in place before our next import to test the UTF-8 part of this, which I think might affect inputs as well.  Not sure where to find some UTF-8 characters however.
 