### PR TITLE
Always clear abort timeouts

### DIFF
--- a/experts-api/lib/elements-client.js
+++ b/experts-api/lib/elements-client.js
@@ -89,7 +89,6 @@ export class Impersonator {
         ...options,
         signal: controller.signal
       });
-      clearTimeout(id);
     } catch (e) {
       if (e.name === 'AbortError') {
         const error=new Error('Request timed out');
@@ -97,6 +96,8 @@ export class Impersonator {
         throw error;
       }
       throw e;
+    } finally {
+      clearTimeout(id);
     }
 
     if (resp.status !== 204 && resp.status !== 200) {


### PR DESCRIPTION
This always clears an abort timeout.  It may prevent read requests from aborted fetches, not sure how that could have worked. 
it's the recommended practice, however.
