### PR TITLE
Always add websites

### DIFF
--- a/harvest/experts-client/lib/query/expert/construct.rq
+++ b/harvest/experts-client/lib/query/expert/construct.rq
@@ -129,15 +129,17 @@ WHERE {
         }
         bind(?pos as ?web_rank)
       }
-      values (?field_name ?field_predicate ) {
-        ("overview" vivo:overview)
-        ("research-interests" ucdlib:researchInterests)
-        ("teaching-summary" ucdlib:teachingSummary)
-      }
-      ?native :field [ :name ?field_name;
-                       :text [ :field-value ?field_value;
-                               :privacy "public"; ]
-                     ].
+      OPTIONAL {
+        values (?field_name ?field_predicate ) {
+          ("overview" vivo:overview)
+          ("research-interests" ucdlib:researchInterests)
+          ("teaching-summary" ucdlib:teachingSummary)
+        }
+        ?native :field [ :name ?field_name;
+                         :text [ :field-value ?field_value;
+                                 :privacy "public"; ]
+                       ].
+        }
     }
     OPTIONAL {
       values (?scheme ?vocab) { ("for" FoR:) }


### PR DESCRIPTION
There was an error in the expert construction that required some bibliographic information to exist or else it wouldn't add websites.  This change makes bibliographic information optional as well. 