### PR TITLE
email is exact search

### DIFF
--- a/experts-api/lib/keycloak-admin.js
+++ b/experts-api/lib/keycloak-admin.js
@@ -116,8 +116,9 @@ export default class ExpertsKcAdminClient extends KcAdminClient {
     //try to find the user in keycloak using the IDP email as the username
     try {
       //get the users from keycloak
-      const users = await this.users.findOne({
+      const users = await this.users.find({
         email: email,
+        exact: true
       });
       return users[0];
     } catch (error) {


### PR DESCRIPTION
This requires and *exact* match on emails, which is what we expected.  We know for sure this affected `provost@ucdavis.edu`  as well as `pawu@ucdavis.edu` We can count any additional experts affected on the 2024-06-06 update.