### PR TITLE
[FEAT] Add bin/experts-count for weekly reviews

### DIFF
--- a/bin/count-experts
+++ b/bin/count-experts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# These Global Variables are the defaults values for the current setup.
+declare -g -A G=(
+  [csv]="experts.csv"
+  # Below you probably don't need to change
+  [host]="https://experts.ucdavis.edu"
+  [shell_getopt]=${FLAGS_GETOPT_CMD:-getopt}
+  [dry-run]=
+  [jwt]=''
+);
+
+if ! opts=$(${G[shell_getopt]} -o h:j:c: --long host:,jwt:,csv: -n "count-experts" -- "$@"); then
+    echo "Bad Command Options." >&2 ; exit 1 ; fi
+
+    eval set -- "$opts"
+
+    while true; do
+        case "$1" in
+            -h | --host ) G[host]="$2"; shift 2 ;;
+            -j | --jwt ) G[jwt]="$2"; shift 2 ;;
+            -c | --csv ) G[csv]="$2"; shift 2 ;;
+            -- ) shift; break ;;
+            * ) break ;;
+        esac
+    done
+
+    if [ -z "${G[jwt]}" ]; then
+      echo "JWT is required. Use -j or --jwt to provide it." >&2 ; exit 1 ;
+    fi
+
+    host=${G[host]}
+    # set session
+    http --session=dev ${host}/api/browse/ Authorization:"Bearer ${G[jwt]}"
+    http='http --session-read-only=dev'
+    for i in A B C D E F G H I J K L M N O P Q R S T U V W X Y Z; do
+      for e in $($http $host/api/browse p==$i page==1 size==1000  | jq -r '.hits[]["@id"]'); do
+        $http POST $host/api/$e <<<'{"grants" : {"include" : true,"size":2000},"works" : {"include" : true,"size":10000}}' | jq -r --arg i "$i" --arg e "$e" '.name as $n | (.["@graph"] | map(select(.["@graph"]["@type"] == "Grant" or (.["@type"][]? == "Grant"))) | length ) as $grants | .["@graph"] | map(select(.["@type"] == "Work" or (.["@type"][]? == "Work"))) | { expert:$e,name:$n,grants:$grants,rank:map(select(.relatedBy | has("rank"))) | length , no_rank:map(select(.relatedBy | has("rank") | not)) | length } | [$i,.expert,.name,.rank,.no_rank,.grants] | @csv';
+  done;
+done | tee ${G[csv]}


### PR DESCRIPTION
This adds a function to count the experts grants and citations, using the API and jq.  It's what I use to fill the weekly summaries.   Usually I just pull the jwt token from my browser.

```bash
bin/count-experts --host=https://stage.experts.library.ucdavis.edu --jwt="$jwt"
```
