### PR TITLE
Exit when sub a process fails - commonly no Fuseki server running

### DIFF
--- a/harvest/experts-client/bin/experts-grant-feed-process.js
+++ b/harvest/experts-client/bin/experts-grant-feed-process.js
@@ -12,6 +12,7 @@ import fs from 'fs';
 // Trick for getting __dirname in ES6 modules
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
+import { exit } from 'process';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const gs = new GoogleSecret();
@@ -102,12 +103,12 @@ params.push('--log=' + logLevel);
 log.info('Parameters1:', params);
 log.info(__dirname + '/experts-grant-feed.js', params);
 const result1 = spawnSync('node', [__dirname + '/experts-grant-feed.js', ...params], { encoding: 'utf8' });
-
 log.info('Output 1:', result1.stdout);
-if (result1.error) {
-  log.error('Execution error 1:', result1.error);
+if (result1.status !== 0) {
+  console.error('Error executing experts-grant-feed.js:', result1.stderr);
+  process.exit(result1.status);
 }
-log.info('Exit code 1:', result1.status);
+log.info('Output 1:', result1.stdout);
 
 const params2 = ['--env=' + opt.env, '--xml=' + opt.xml, '--generation=' + opt.prev, '--output=' + opt.output];
 params2.push('--log=' + logLevel);
@@ -116,8 +117,9 @@ log.info('Parameters2:', params2);
 log.info(__dirname + '/experts-grant-feed.js', params2);
 const result2 = spawnSync('node', [__dirname + '/experts-grant-feed.js', ...params2], { encoding: 'utf8' });
 log.info('Output 2:', result2.stdout);
-if (result2.error) {
-  log.error('Execution error 2:', result2.error);
+if (result2.status !== 0) {
+  console.error('Error executing experts-grant-feed.js:', result2.stderr);
+  process.exit(result2.status);
 }
 log.info('Exit code 2:', result2.status);
 
@@ -128,8 +130,9 @@ log.info('Parameters2:', params3);
 log.info(__dirname + '/experts-grant-feed-delta.js', params3);
 const result3 = spawnSync('node', [__dirname + '/experts-grant-feed-delta.js', ...params3], { encoding: 'utf8' });
 log.info('Output 3:', result3.stdout);
-if (result3.error) {
-  log.error('Execution error 3:', result3.error);
+if (result3.status !== 0) {
+  console.error('Error executing experts-grant-feed-delta.js:', result2.stderr);
+  process.exit(result2.status);
 }
 log.info('Exit code 3:', result3.status);
 


### PR DESCRIPTION
The experts-grant-feed-process.js script makes 3 calls with spawnSync that don't handle failed results.