### PR TITLE
Import with (assert { type: 'json' }) is deprecated in Node.js v22.0.…

### DIFF
--- a/harvest/experts-client/bin/experts.js
+++ b/harvest/experts-client/bin/experts.js
@@ -2,7 +2,7 @@
 
 import { Command } from 'commander';
 const program = new Command();
-import pkg from '../package.json' assert { type: "json" };
+import pkg from '../package.json' with { type: "json" };
 
 program
   .name('experts')


### PR DESCRIPTION
…0 and will be removed in v24.0.0