### PR TITLE
[FEAT] FUSEKI_PORT for dev only.

### DIFF
--- a/bin/aggie-experts
+++ b/bin/aggie-experts
@@ -518,14 +518,6 @@ function setup() {
     local template=$(expand_template)
     local root="$(${G[git]} rev-parse --show-toplevel)"
 
-    # Delete unused PORTS
-    for i in fuseki kibana fcrepo rabbitmq; do
-      local p=${i^^}_PORT
-      if [[ -z "${!p}" ]]; then
-        yq="$yq | del(.services.$i.ports)"
-      fi
-    done
-
     if [[ -z ${G[gcs]} ]]; then
       yq+='| del(.services.gcs)'
     fi
@@ -545,7 +537,7 @@ function setup() {
       fi
     # These are potential others
     else
-      yq+='| del(.. | select(anchor=="DEV_MOUNT*" or alias=="DEV_MOUNT*"))'
+      yq+='| del(.services.fuseki.ports) | del(.. | select(anchor=="DEV_MOUNT*" or alias=="DEV_MOUNT*"))'
     fi
     if [[ -n $N ]]; then
       echo "yq '${yq}' <<<'${template}'"

--- a/docker-template.yaml
+++ b/docker-template.yaml
@@ -64,8 +64,8 @@ services:
   fcrepo:
     image: ${D[build_org]}/fin-fcrepo:${D[fin_tag]}
     logging: *LOGGING
-    ports:
-      - ${FCREPO_PORT}:8080
+    #ports:
+    #  - ${FCREPO_PORT}:8080
    # Example for change logging.  Note, don't forget to still include the fcrepo.properties file location!
     # See: https://wiki.lyrasis.org/display/FEDORA6x/Logging
     # environment:
@@ -239,8 +239,8 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:8.4.3
     logging: *LOGGING
-    ports:
-      - ${KIBANA_PORT}:5601
+    #ports:
+    #  - ${KIBANA_PORT}:5601
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
       - ELASTICSEARCH_URL=http://elasticsearch:9200


### PR DESCRIPTION
This eliminates most ports from ever being exposed to the OS.  However,  if you are in `--env=dev` and setup, then it will expose fuseki.  You can either set `FUSEKI_PORT` in your .env file, or track down the ephemeral port it will be using. 