### PR TITLE
[FEAT] Remove stop words for phrase match

### DIFF
--- a/services/base-service/models/base/schema/settings.json
+++ b/services/base-service/models/base/schema/settings.json
@@ -155,7 +155,6 @@
         "filter": [
           "email_to_mailto","xxx_to_doi","xxx_to_orcid", "n2t_to_id",
           "lowercase",
-          "stop",
           "asciifolding"
         ]
       },
@@ -169,7 +168,6 @@
         "filter": [
           "email_to_mailto","xxx_to_doi","xxx_to_orcid", "n2t_to_id",
           "lowercase",
-          "stop",
           "asciifolding"
         ]
       },

--- a/services/base-service/models/search/template/complete.js
+++ b/services/base-service/models/search/template/complete.js
@@ -102,66 +102,74 @@ template = {
             "nested": {
               "path": "@graph",
               "query": {
-                "bool" : {
-                  "must": [
-                    {
-                      "multi_match": {
-                        "query": "{{q}}",
-                        "fields": [
-                          "@graph.@id^10",
-                          "@graph.relates^2",
-                          "@graph.DOI^10",
-                          "@graph.abstract^5",
-                          "@graph.contactInfo.hasEmail^10",
-                          "@graph.contactInfo.hasName.family^20",
-                          "@graph.contactInfo.hasName.given^5",
-                          "@graph.contactInfo.hasName.middle^5",
-                          "@graph.contactInfo.hasTitle.name^5",
-                          "@graph.contactInfo.hasURL.name^5",
-                          "@graph.contactInfo.hasOrganizationalUnit.name^5",
-                          "@graph.name^10",
-                          "@graph.orcidId^10",
-                          "@graph.overview^5",
-                          "@graph.abstract^5",
-                          "@graph.identifier^10",
-                          "@graph.container-title^5",
-                          "@graph.publisher^5",
-                          "@graph.title^10"
-                        ]
-                      } } ],
-                    "filter": [
-                    {
-                      "bool": {
-                        "should": [
-                          {
-                            "bool": {
-                              "must": [
-                                { "exists": { "field": "@graph.is-visible" }},
-                                { "term": { "@graph.is-visible": true }}
-                              ]
+                "function_score": {
+                   "query": {
+                        "bool" : {
+                          "must": [
+                            {
+                              "simple_query_string": {
+                                "query": "{{q}}",
+                                "fields": [
+                                  "@graph.@id^10",
+                                  "@graph.relates^2",
+                                  "@graph.DOI^10",
+                                  "@graph.abstract^5",
+                                  "@graph.contactInfo.hasEmail^10",
+                                  "@graph.contactInfo.hasName.family^20",
+                                  "@graph.contactInfo.hasName.given^5",
+                                  "@graph.contactInfo.hasName.middle^5",
+                                  "@graph.contactInfo.hasTitle.name^5",
+                                  "@graph.contactInfo.hasURL.name^5",
+                                  "@graph.contactInfo.hasOrganizationalUnit.name^5",
+                                  "@graph.name^10",
+                                  "@graph.orcidId^10",
+                                  "@graph.overview^5",
+                                  "@graph.abstract^5",
+                                  "@graph.identifier^10",
+                                  "@graph.container-title^5",
+                                  "@graph.publisher^5",
+                                  "@graph.title^10"
+                                ],
+                                "default_operator": "and"
+                              } } ],
+                            "filter": [
+                            {
+                              "bool": {
+                                "should": [
+                                  {
+                                    "bool": {
+                                      "must": [
+                                        { "exists": { "field": "@graph.is-visible" }},
+                                        { "term": { "@graph.is-visible": true }}
+                                      ]
+                                    }
+                                  },
+                                  {
+                                    "bool": {
+                                      "must": [
+                                        { "exists": { "field": "@graph.relatedBy.is-visible" }},
+                                        { "term": { "@graph.relatedBy.is-visible": true }}
+                                      ]
+                                    }
+                                  }
+                                ],
+                                "minimum_should_match": 1
+                              }
                             }
-                          },
-                          {
-                            "bool": {
-                              "must": [
-                                { "exists": { "field": "@graph.relatedBy.is-visible" }},
-                                { "term": { "@graph.relatedBy.is-visible": true }}
-                              ]
-                            }
-                          }
-                        ],
-                        "minimum_should_match": 1
-                      }
-                    }
-                  ]
-                }
+                          ]
+                        }
+                      },
+                      "min_score": {{min_nested_score}}{{^min_nested_score}}1.0{{/min_nested_score}},
+                      "boost_mode": "replace"
+                   }
               },
               "inner_hits": {
                 "size": "{{inner_hits_size}}{{^inner_hits_size}}500{{/inner_hits_size}}",
                 "_source": [
                   "@graph.@id",
                   "@graph.@type",
-                  "@graph.name"
+                  "@graph.name",
+                  "_score"
                 ]
               },
               "score_mode": "sum"
@@ -216,7 +224,8 @@ template = {
         "sponsorAwardId",
         "assignedBy",
         "dateTimeInterval",
-        "relatedBy"
+        "relatedBy",
+        "_score"
       ],
       "sort": [
         "_score",
@@ -224,10 +233,13 @@ template = {
         "name.kw"
       ],
       "from": "{{from}}{{^from}}0{{/from}}",
-      "size": "{{size}}{{^size}}10{{/size}}"
+      "size": "{{size}}{{^size}}10{{/size}}",
+      "min_score": "{{min_score}}{{^min_score}}5.0{{/min_score}}"
     },
     "params": {
-      "q": "My query string"
+      "q": "My query string",
+      "min_nested_score": 10.0,
+      "min_score": 10.0,
     }
   }`
   }


### PR DESCRIPTION
This is a required, bun insufficient, change for indexing.  We are removing the stop word token deletion.  This will allow "and" concatenation for our searches.   This is so I can do an index on stage.